### PR TITLE
change inclusive range syntax to new ..= syntax

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moz_cbor"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Franziskus Kiefer <franziskuskiefer@gmail.com>", "David Keeler <dkeeler@mozilla.com>"]
 description = "Library to use CBOR (https://tools.ietf.org/html/rfc7049) in Rust"
 repository = "https://github.com/franziskuskiefer/cbor-rust"

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -48,7 +48,7 @@ impl<'a> DecoderCursor<'a> {
     fn read_int(&mut self) -> Result<u64, CborError> {
         let first_value = self.read_uint_from_bytes(1)? & INITIAL_VALUE_MASK;
         match first_value {
-            0...23 => Ok(first_value),
+            0..=23 => Ok(first_value),
             24 => self.read_uint_from_bytes(1),
             25 => self.read_uint_from_bytes(2),
             26 => self.read_uint_from_bytes(4),

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -7,19 +7,19 @@ fn common_encode_unsigned(output: &mut Vec<u8>, tag: u8, value: u64) {
     assert!(tag < 8);
     let shifted_tag = tag << 5;
     match value {
-        0...23 => {
+        0..=23 => {
             output.push(shifted_tag | (value as u8));
         }
-        24...255 => {
+        24..=255 => {
             output.push(shifted_tag | 24);
             output.push(value as u8);
         }
-        256...65_535 => {
+        256..=65_535 => {
             output.push(shifted_tag | 25);
             output.push((value >> 8) as u8);
             output.push((value & 255) as u8);
         }
-        65_536...4_294_967_295 => {
+        65_536..=4_294_967_295 => {
             output.push(shifted_tag | 26);
             output.push((value >> 24) as u8);
             output.push(((value >> 16) & 255) as u8);


### PR DESCRIPTION
rust has obsoleted the ... syntax for inclusive ranges, but I think replaced with ..=
